### PR TITLE
Update coqQ with Rocq Prover 9.0 and Mac instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ NAME     := coq-mathcomp-quantum
 DISTDIR  := $(NAME)
 SED      := sed
 TAR      := tar
-REPO     := default=https://opam.ocaml.org,coq-released=https://coq.inria.fr/opam/released
+REPO     := default=https://opam.ocaml.org,rocq-released=https://rocq-prover.org/opam/released,coq-released=https://coq.inria.fr/opam/released
 
 # --------------------------------------------------------------------
 .PHONY: default build build-local opam clean mrproper dist distcheck

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 We depend on the following external libraries:
 
 ```
-  "coq"                      { = "8.18.0"           }
-  "coq-core"                 { = "8.18.0"           }
+  "coq"                      { = "9.0.0"            }
+  "coq-core"                 { = "9.0.0"            }
   "coq-elpi"                 { = "2.0.0"            }
   "dune"                     {>= "3.2" & <= "3.13.0"}
   "dune-configurator"        { = "3.12.1"           }
@@ -23,7 +23,7 @@ The easiest way to install the above libraries is via [OPAM](https://opam.ocaml.
 opam switch create \
     --yes \
     --deps-only \
-    --repositories=default=https://opam.ocaml.org,coq-released=https://coq.inria.fr/opam/released \
+    --repositories=default=https://opam.ocaml.org,rocq-released=https://rocq-prover.org/opam/released,coq-released=https://coq.inria.fr/opam/released \
     .
 ```
 
@@ -32,9 +32,34 @@ config exec -- make` if you used a local opam switch to install the
 dependencies).
 
 Remark: if any unexpected error occurs, please follow the exact version of the 
-above libraries. It's known that dune-configurator >= 3.13.0 will kill the 
-compilation (incompatible with coq.8.18.0 if use `-(notation)` attribute 
-for importing files).
+above libraries. It's known that dune-configurator >= 3.13.0 may break the 
+compilation (was incompatible with Coq 8.18 when using `-(notation)` attribute
+for importing files). With Rocq 9.0, we still pin dune-configurator to 3.12.1.
+
+## macOS instructions (Rocq Prover 9.0)
+
+You can install Rocq Prover 9.0 on macOS either via the Rocq Platform app or via opam.
+
+- Rocq Platform (recommended):
+  1. Download the latest DMG from the Rocq Platform releases page.
+  2. Drag the app into `/Applications` and open it once via right-click → Open.
+  3. Optional: add binaries to PATH for terminal use:
+     ```bash
+     export PATH="/Applications/Coq_Platform_2025.01.0.app/Contents/Resources/bin:$PATH"
+     ```
+  4. Verify: `coqtop -v` should show Rocq 9.0.
+
+- Opam (command-line):
+  1. Install opam (e.g., via Homebrew: `brew install opam`).
+  2. Initialize: `opam init -y && eval $(opam env)`.
+  3. Add repos and install deps:
+     ```bash
+     opam repo add rocq-released https://rocq-prover.org/opam/released
+     opam repo add default https://opam.ocaml.org || true
+     opam repo add coq-released https://coq.inria.fr/opam/released || true
+     opam switch create --yes --deps-only --repositories=default=https://opam.ocaml.org,rocq-released=https://rocq-prover.org/opam/released,coq-released=https://coq.inria.fr/opam/released .
+     ```
+  4. Build the project: `opam config exec -- make`.
 
 <br>
 

--- a/coq-mathcomp-quantum.opam
+++ b/coq-mathcomp-quantum.opam
@@ -5,11 +5,11 @@ license: "CeCILL-B"
 authors: ["Coq Quantum Dev. Team"]
 build: [ "dune" "build" "-p" name "-j" jobs ]
 depends: [
-  "coq"                      { = "8.18.0"           }
-  "coq-core"                 { = "8.18.0"           }
+  "coq"                      { = "9.0.0"            }
+  "coq-core"                 { = "9.0.0"            }
   "coq-elpi"                 { = "2.0.0"            }
   "dune"                     {>= "3.2" & <= "3.13.0"}
-  "dune-configurator"        { = "3.13.1"           }
+  "dune-configurator"        { = "3.12.1"           }
   "coq-hierarchy-builder"    { = "1.7.0"            }
   "coq-mathcomp-ssreflect"   { = "2.2.0"            }
   "coq-mathcomp-algebra"     { = "2.2.0"            }


### PR DESCRIPTION
Update project to Rocq Prover 9.0 and add macOS installation instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-6eb25453-b377-414d-a89d-ada6d49d1f9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6eb25453-b377-414d-a89d-ada6d49d1f9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Update the project to use Rocq Prover 9.0 by bumping Coq dependencies, adding the rocq-released OPAM repository, and providing macOS installation instructions.

New Features:
- Add macOS installation instructions for Rocq Prover 9.0 via the Rocq Platform app and opam

Enhancements:
- Upgrade coq and coq-core dependencies to version 9.0.0
- Include the rocq-released repository in OPAM configuration and the Makefile
- Pin dune-configurator to 3.12.1 for compatibility with Rocq Prover 9.0